### PR TITLE
Report running total of new users for months queried.

### DIFF
--- a/tests/status/test_usage_status.py
+++ b/tests/status/test_usage_status.py
@@ -16,10 +16,9 @@ MAX_DAILY_EXPECTED = [{'max_user_per_day': 6, 'month': 11, 'year': 2023},
                       {'max_user_per_day': 1, 'month': 9, 'year': 2023},
                       {'max_user_per_day': 1, 'month': 8, 'year': 2023}]
 
-NEW_USERS_EXPECTED = [{'month': 10, 'new_users': 1, 'year': 2023},
-                      {'month': 9, 'new_users': 2, 'year': 2023},
-                      {'month': 8, 'new_users': 1, 'year': 2023}]
-
+NEW_USERS_EXPECTED = [{'month': 10, 'new_users': 1, 'run_total': 4, 'year': 2023},
+                      {'month': 9, 'new_users': 2, 'run_total': 3, 'year': 2023},
+                      {'month': 8, 'new_users': 1, 'run_total': 1, 'year': 2023}]
 
 TOTAL_USERS_EXPECTED = 4
 


### PR DESCRIPTION
Adds `run_total` key to each of the months output under the `new_users` key of the usage endpoint.

```json
[{"month": 10, "new_users": 20, "run_total": 90, "year": 2023},                                                                             
{"month": 9, "new_users": 30, "run_total": 70, "year": 2023},                                                                               
{"month": 8, "new_users": 40, "run_total": 30, "year": 2023}]
```

Closes #26